### PR TITLE
content-retriever: create getContentFactors 

### DIFF
--- a/lib/content-retriever.js
+++ b/lib/content-retriever.js
@@ -246,6 +246,8 @@ class ContentRetriever {
                     * videoURL - URL string to override metadata.videoURL
                     * thumbnailURL - URL string to override metadata.thumbnailURL
                     */
+                    debugLog(urlKey);
+
                     if (body[urlKey]) {
                         data.docs[0].coverArt = body[urlKey].coverArt[0] ? body[urlKey].coverArt : false;
                         data.docs[0].pageTopOverride = body[urlKey].useCMS.pageTopOverride ? body[urlKey].pageTopOverride : false;

--- a/lib/content-retriever.js
+++ b/lib/content-retriever.js
@@ -201,30 +201,32 @@ class ContentRetriever {
 
 
     /**
-     * Gets any associated coverart with the canonical url for the sourceModel
-     * that is passed in.  If cover art is found, it is stitched into the model
-     * before it is returned.
+     * Gets any associated factors with the canonical url for the sourceModel
+     * that is passed in.  If factors are found, it is stitched into the model
+     * before it is returned. (Possible factors: coverArt, pageTopOverride,
+     * thumbnailURL, videoURL, useCMS.)
      *
      * @param {Object} data
      * A content model returned from `getBaseContentModel` or `getRelatedContent`.
      *
      * @returns {Promise}
      * Returns a promise with the content model that was passed in with the
-     * `coverArt` object stitched in at the appropriate level.
+     * factors object. In addition, useCMS object controls whether to use
+     * overrides for the pageTopOverride, videoURL, or thumbnailURL.
      *
      * @example
      * contentRetriever.getBaseContentModel().then((baseModel) => {
      *     contentRetriever.getRelatedContent(baseModel).then((resolvedModel) => {
-     *         contentRetriever.getCoverArt(resolvedModel).then((resolvedModelWithCoverArtIfApplicable) => {
-     *             console.log(resolvedModelWithCoverArtIfApplicable);
+     *         contentRetriever.getContentFactors(resolvedModel).then((resolvedModelWithCoverArtIfApplicable) => {
+     *             console.log(resolvedModelWithCoverArtIfApplicablePlusOverrides);
      *         });
      *     });
      * });
      */
-    getCoverArt(data) {
+    getContentFactors(data) {
         let self = this,
-            debugLog = debug('cnn-content-retriever:getCoverArt'),
-            url = 'http://data.cnn.com/content/ksa/coverart.json';
+            debugLog = debug('cnn-content-retriever:getContentFactors'),
+            url = 'http://data.cnn.com/content/ksa/factors.json';
 
         return new Promise((resolve) => {
             debugLog(`Requesting ${url} with timeout: ${self.timeout}`);
@@ -237,9 +239,17 @@ class ContentRetriever {
                                     .replace(/\./g, '_')
                                     .replace(/\-/g, '_')
                                     .replace(/\//g, '_');
-
+                    /**
+                    * useCMS - If true, honor CMS. If false, use override.
+                    * pageTopOverride - Object to override pageTop.
+                    * metadata.videoURL - URL string to override a metadata.videoURL
+                    * metadata.thumbnailURL - URL string to override article thumbnailURL
+                    */
                     if (body[urlKey]) {
                         data.docs[0].coverArt = body[urlKey].coverArt;
+                        data.docs[0].pageTopOverride = body[urlKey].useCMS.pageTopOverride ? body[urlKey].pageTopOverride : false;
+                        data.docs[0].videoURL = body[urlKey].useCMS.videoURL ? body[urlKey].videoURL : false;
+                        data.docs[0].thumbnailURL = body[urlKey].useCMS.thumbnailURL ? body[urlKey].thumbnailURL : false;
                     }
 
                     debugLog(data);

--- a/lib/content-retriever.js
+++ b/lib/content-retriever.js
@@ -245,9 +245,9 @@ class ContentRetriever {
                     * thumbnailURL - URL string to override metadata.thumbnailURL
                     */
                     if (body[urlKey]) {
-                        data.docs[0].coverArt = body[urlKey].coverArt;
+                        data.docs[0].coverArt = body[urlKey].coverArt[0] ? body[urlKey].coverArt : false;
                         data.docs[0].pageTopOverride = body[urlKey].useCMS.pageTopOverride ? body[urlKey].pageTopOverride : false;
-                        data.docs[0].videoURLThumbnail = body[urlKey].useCMS.videoURLThumbnail ? body[urlKey].videoURL : false;
+                        data.docs[0].videoURLThumbnail = body[urlKey].useCMS.videoURLThumbnail ? body[urlKey].videoURLThumbnail : false;
                         data.docs[0].thumbnailURL = body[urlKey].useCMS.thumbnailURL ? body[urlKey].thumbnailURL : false;
                     }
 

--- a/lib/content-retriever.js
+++ b/lib/content-retriever.js
@@ -204,7 +204,7 @@ class ContentRetriever {
      * Gets any associated factors with the canonical url for the sourceModel
      * that is passed in.  If factors are found, it is stitched into the model
      * before it is returned. (Possible factors: coverArt, pageTopOverride,
-     * thumbnailURL, videoURLThumbnail, useCMS.)
+     * thumbnailURL, videoURL, useCMS.)
      *
      * @param {Object} data
      * A content model returned from `getBaseContentModel` or `getRelatedContent`.
@@ -219,8 +219,8 @@ class ContentRetriever {
      * @example
      * contentRetriever.getBaseContentModel().then((baseModel) => {
      *     contentRetriever.getRelatedContent(baseModel).then((resolvedModel) => {
-     *         contentRetriever.getContentFactors(resolvedModel).then((resolvedModelWithCoverArtIfApplicable) => {
-     *             console.log(resolvedModelWithCoverArtIfApplicablePlusOverrides);
+     *         contentRetriever.getContentFactors(resolvedModel).then((resolvedModelWithContentFactors) => {
+     *             console.log(resolvedModelWithContentFactors);
      *         });
      *     });
      * });

--- a/lib/content-retriever.js
+++ b/lib/content-retriever.js
@@ -249,10 +249,10 @@ class ContentRetriever {
                     debugLog(urlKey);
 
                     if (body[urlKey]) {
-                        data.docs[0].coverArt = body[urlKey].coverArt[0] ? body[urlKey].coverArt : false;
-                        data.docs[0].pageTopOverride = body[urlKey].useCMS.pageTopOverride ? body[urlKey].pageTopOverride : false;
-                        data.docs[0].videoURL = body[urlKey].useCMS.videoURL ? body[urlKey].videoURL : false;
-                        data.docs[0].thumbnailURL = body[urlKey].useCMS.thumbnailURL ? body[urlKey].thumbnailURL : false;
+                        data.docs[0].coverArt = (body[urlKey].coverArt[0] === false) ? body[urlKey].coverArt : undefined;
+                        data.docs[0].pageTopOverride = (body[urlKey].useCMS.pageTopOverride === false) ? body[urlKey].pageTopOverride : undefined;
+                        data.docs[0].videoURL = (body[urlKey].useCMS.videoURL === false) ? body[urlKey].videoURL : undefined;
+                        data.docs[0].thumbnailURL = (body[urlKey].useCMS.thumbnailURL === false) ? body[urlKey].thumbnailURL : undefined;
                     }
 
                     debugLog(data);

--- a/lib/content-retriever.js
+++ b/lib/content-retriever.js
@@ -209,6 +209,9 @@ class ContentRetriever {
      * @param {Object} data
      * A content model returned from `getBaseContentModel` or `getRelatedContent`.
      *
+     * @param {String} url
+     * Url for config object.
+     *
      * @returns {Promise}
      * Returns a promise with the content model that was passed in with the
      * factors object.
@@ -222,10 +225,9 @@ class ContentRetriever {
      *     });
      * });
      */
-    getContentFactors(data) {
+    getContentFactors(data, url) {
         let self = this,
-            debugLog = debug('cnn-content-retriever:getContentFactors'),
-            url = 'http://data.cnn.com/content/ksa/factors.json';
+            debugLog = debug('cnn-content-retriever:getContentFactors');
 
         return new Promise((resolve) => {
             debugLog(`Requesting ${url} with timeout: ${self.timeout}`);
@@ -241,13 +243,13 @@ class ContentRetriever {
                     /**
                     * useCMS - If true, honor CMS. If false, use override.
                     * pageTopOverride - Object to override pageTop.
-                    * videoURLThumbnail - URL string to override metadata.videoURL
+                    * videoURL - URL string to override metadata.videoURL
                     * thumbnailURL - URL string to override metadata.thumbnailURL
                     */
                     if (body[urlKey]) {
                         data.docs[0].coverArt = body[urlKey].coverArt[0] ? body[urlKey].coverArt : false;
                         data.docs[0].pageTopOverride = body[urlKey].useCMS.pageTopOverride ? body[urlKey].pageTopOverride : false;
-                        data.docs[0].videoURLThumbnail = body[urlKey].useCMS.videoURLThumbnail ? body[urlKey].videoURLThumbnail : false;
+                        data.docs[0].videoURL = body[urlKey].useCMS.videoURL ? body[urlKey].videoURL : false;
                         data.docs[0].thumbnailURL = body[urlKey].useCMS.thumbnailURL ? body[urlKey].thumbnailURL : false;
                     }
 

--- a/lib/content-retriever.js
+++ b/lib/content-retriever.js
@@ -204,15 +204,14 @@ class ContentRetriever {
      * Gets any associated factors with the canonical url for the sourceModel
      * that is passed in.  If factors are found, it is stitched into the model
      * before it is returned. (Possible factors: coverArt, pageTopOverride,
-     * thumbnailURL, videoURL, useCMS.)
+     * thumbnailURL, videoURLThumbnail, useCMS.)
      *
      * @param {Object} data
      * A content model returned from `getBaseContentModel` or `getRelatedContent`.
      *
      * @returns {Promise}
      * Returns a promise with the content model that was passed in with the
-     * factors object. In addition, useCMS object controls whether to use
-     * overrides for the pageTopOverride, videoURL, or thumbnailURL.
+     * factors object.
      *
      * @example
      * contentRetriever.getBaseContentModel().then((baseModel) => {
@@ -242,13 +241,13 @@ class ContentRetriever {
                     /**
                     * useCMS - If true, honor CMS. If false, use override.
                     * pageTopOverride - Object to override pageTop.
-                    * metadata.videoURL - URL string to override a metadata.videoURL
-                    * metadata.thumbnailURL - URL string to override article thumbnailURL
+                    * videoURLThumbnail - URL string to override metadata.videoURL
+                    * thumbnailURL - URL string to override metadata.thumbnailURL
                     */
                     if (body[urlKey]) {
                         data.docs[0].coverArt = body[urlKey].coverArt;
                         data.docs[0].pageTopOverride = body[urlKey].useCMS.pageTopOverride ? body[urlKey].pageTopOverride : false;
-                        data.docs[0].videoURL = body[urlKey].useCMS.videoURL ? body[urlKey].videoURL : false;
+                        data.docs[0].videoURLThumbnail = body[urlKey].useCMS.videoURLThumbnail ? body[urlKey].videoURL : false;
                         data.docs[0].thumbnailURL = body[urlKey].useCMS.thumbnailURL ? body[urlKey].thumbnailURL : false;
                     }
 


### PR DESCRIPTION
With additions to enable a dynamic config to override content factors,
changes should be made to allow projects downstream to consume these new
factors.

Fixes: CNNAPPNEWS-173
Reviewed-By: Katie Owen <katherine.owen@turner.com>